### PR TITLE
修复由于FileCacheQueueScheduler中fileCursor 文件再次打开时没有初始化抛出NullPointerExceptio...

### DIFF
--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
@@ -126,7 +126,7 @@ public class FileCacheQueueScheduler implements Scheduler {
     private void readCursorFile() throws IOException {
         BufferedReader fileCursorReader = null;
         try {
-            new BufferedReader(new FileReader(getFileName(fileCursor)));
+        	fileCursorReader = new BufferedReader(new FileReader(getFileName(fileCursor)));
             String line;
             //read the last number
             while ((line = fileCursorReader.readLine()) != null) {


### PR DESCRIPTION
...n的错误
