### PR TITLE
Modify the log levels of LocalDuplicatedRemovedScheduler.java

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/scheduler/LocalDuplicatedRemovedScheduler.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/scheduler/LocalDuplicatedRemovedScheduler.java
@@ -23,8 +23,9 @@ public abstract class LocalDuplicatedRemovedScheduler implements Scheduler {
 
     @Override
     public void push(Request request, Task task) {
-        logger.debug("push to queue " + request.getUrl());
+        logger.trace("get a candidate url " + request.getUrl());
         if (request.getExtra(Request.CYCLE_TRIED_TIMES) != null || urls.add(request.getUrl())) {
+        	logger.debug("push to queue " + request.getUrl());
             pushWhenNoDuplicate(request, task);
         }
     }


### PR DESCRIPTION
The old version will print a debug level log each time the push method is
called. So sometimes, when a html page have multiple links for the same
page, the debug log will appears more than once. Also, when we meet a
duplicate URL, it will also print a log, which will be confusing.
I change the level of it to trace. And each time a URL is really push into
queue, print a debug level log.
