### PR TITLE
Update FileCacheQueueScheduler.java

### DIFF
--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
@@ -127,13 +127,13 @@ public class FileCacheQueueScheduler extends DuplicateRemovedScheduler implement
         BufferedReader fileUrlReader = null;
         try {
             fileUrlReader = new BufferedReader(new FileReader(getFileName(fileUrlAllName)));
-            int lineReaded = 0;
+            //int lineReaded = 0;
             while ((line = fileUrlReader.readLine()) != null) {
                 urls.add(line.trim());
-                lineReaded++;
+                /*lineReaded++;
                 if (lineReaded > cursor.get()) {
                     queue.add(new Request(line));
-                }
+                }*/
             }
         } finally {
             if (fileUrlReader != null) {


### PR DESCRIPTION
在使用过程中发现了这么一种情况,有时cursor.txt文件为空,可能停止java进程非常不巧,还没来得及flush(每隔10秒flush)或刚刚覆盖了(或清空了)cursor.txt文件.于是下次启动抓取进程时,会将urls.txt文件中的url全部添加到queue中,于是urls.txt中那些已抓取的url又会被重新抓取一遍.
按我的理解,只要是在urls.txt文件中的url,就表示已经抓取过了,不管什么情况,好像都没必要再添加到queue中了.并且照这样看来的话,连cursor文件都可以省略. 不知有什么隐情使得需要cursor文件来配合? 同时根据我的理解做了上述的修改,还请您审阅.
