### PR TITLE
Update Site.java

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/Site.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/Site.java
@@ -331,7 +331,7 @@ public class Site {
     }
 
     /**
-     * Set cycleRetryTimes times when download fail, 0 by default. Only work in RedisScheduler. <br>
+     * Set cycleRetryTimes times when download fail, 0 by default. <br>
      *
      * @return this
      */


### PR DESCRIPTION
setCycleRetryTimes的javadoc是这么说的:Set cycleRetryTimes times when download fail, 0 by default. Only work in RedisScheduler.
而通过查看源码发现似乎并没有做限制,即只能用于RedisScheduler. 故想问一下该javadoc是否过时了?
