### PR TITLE
Update FileCacheQueueScheduler.java

### DIFF
--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
@@ -134,6 +134,7 @@ public class FileCacheQueueScheduler extends DuplicateRemovedScheduler implement
             int lineReaded = 0;
             while ((line = fileUrlReader.readLine()) != null) {
                 //urls.add(line.trim());
+                getDuplicateRemover().isDuplicate(new Request(line), null);
                 lineReaded++;
                 if (lineReaded > cursor.get()) {
                     queue.add(new Request(line));

--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/FileCacheQueueScheduler.java
@@ -42,14 +42,14 @@ public class FileCacheQueueScheduler extends DuplicateRemovedScheduler implement
 
     private BlockingQueue<Request> queue;
 
-    private Set<String> urls;
+   // private Set<String> urls;
 
     public FileCacheQueueScheduler(String filePath) {
         if (!filePath.endsWith("/") && !filePath.endsWith("\\")) {
             filePath += "/";
         }
         this.filePath = filePath;
-        initDuplicateRemover();
+        //initDuplicateRemover();
     }
 
     private void flush() {
@@ -114,7 +114,7 @@ public class FileCacheQueueScheduler extends DuplicateRemovedScheduler implement
     private void readFile() {
         try {
             queue = new LinkedBlockingQueue<Request>();
-            urls = new LinkedHashSet<String>();
+            //urls = new LinkedHashSet<String>();
             readCursorFile();
             readUrlFile();
             // initDuplicateRemover();
@@ -133,7 +133,7 @@ public class FileCacheQueueScheduler extends DuplicateRemovedScheduler implement
             fileUrlReader = new BufferedReader(new FileReader(getFileName(fileUrlAllName)));
             int lineReaded = 0;
             while ((line = fileUrlReader.readLine()) != null) {
-                urls.add(line.trim());
+                //urls.add(line.trim());
                 lineReaded++;
                 if (lineReaded > cursor.get()) {
                     queue.add(new Request(line));


### PR DESCRIPTION
感觉FileCacheQueueScheduler与DuplicateRemover功能耦合了，本来去重只是DuplicateRemover的工作， 而FileCacheQueueScheduler中也有一个urls成员属性(set)， 且在构造方法中初始化了一个DuplicateRemover与默认的HashSetDuplicateRemover没有什么区别（除了一个是LinkedHashSet，一个是Sets.newSetFromMap(new ConcurrentHashMap<String, Boolean>())外）。并且假如内存有瓶颈想改用BloomFilterDuplicateRemover的话， 成员属性urls还在，初始化时（readUrlFile方法）还是会往里添加url元素，且这时该urls集合纯粹是多余的，白占内存而已，使用BloomFilterDuplicateRemover节约内存的目的也不能达成。鱼与熊掌（内存与准确），皆不能得。故做了上述的修改。
