### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/webmagic-core/module_webmagic-core.xml
+++ b/webmagic-core/module_webmagic-core.xml
@@ -24,7 +24,7 @@
     <path refid="library.maven:_com.google.guava:guava:13.0.1.classpath"/>
     <path refid="library.maven:_org.apache.commons:commons-lang3:3.1.classpath"/>
     <path refid="library.maven:_log4j:log4j:1.2.17.classpath"/>
-    <path refid="library.maven:_commons-collections:commons-collections:3.2.1.classpath"/>
+    <path refid="library.maven:_commons-collections:commons-collections:3.2.2.classpath"/>
     <path refid="library.maven:_net.sourceforge.htmlcleaner:htmlcleaner:2.4.classpath"/>
     <path refid="library.maven:_org.jdom:jdom2:2.0.4.classpath"/>
     <path refid="library.maven:_commons-io:commons-io:1.3.2.classpath"/>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
