### PR TITLE
fix the monitor bug which the spider will terminate when a seed url with port

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/utils/UrlUtils.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/utils/UrlUtils.java
@@ -83,6 +83,15 @@ public class UrlUtils {
         return domain;
     }
 
+    public static String removePort(String domain) {
+        int portIndex = domain.indexOf(":");
+        if (portIndex != -1) {
+            return domain.substring(0, portIndex);
+        }else {
+            return domain;
+        }
+    }
+
     /**
      * allow blank space in quote
      */

--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/monitor/SpiderMonitor.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/monitor/SpiderMonitor.java
@@ -6,6 +6,7 @@ import us.codecraft.webmagic.Request;
 import us.codecraft.webmagic.Spider;
 import us.codecraft.webmagic.SpiderListener;
 import us.codecraft.webmagic.utils.Experimental;
+import us.codecraft.webmagic.utils.UrlUtils;
 
 import javax.management.*;
 import java.lang.management.ManagementFactory;
@@ -103,7 +104,8 @@ public class SpiderMonitor {
     }
 
     protected void registerMBean(SpiderStatusMXBean spiderStatus) throws MalformedObjectNameException, InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException {
-        ObjectName objName = new ObjectName(jmxServerName + ":name=" + spiderStatus.getName());
+//        ObjectName objName = new ObjectName(jmxServerName + ":name=" + spiderStatus.getName());
+        ObjectName objName = new ObjectName(jmxServerName + ":name=" + UrlUtils.removePort(spiderStatus.getName()));
         mbeanServer.registerMBean(spiderStatus, objName);
     }
 

--- a/webmagic-extension/src/test/java/us/codecraft/webmagic/monitor/SeedUrlWithPortTest.java
+++ b/webmagic-extension/src/test/java/us/codecraft/webmagic/monitor/SeedUrlWithPortTest.java
@@ -1,0 +1,35 @@
+package us.codecraft.webmagic.monitor;
+
+import org.junit.Test;
+import us.codecraft.webmagic.Page;
+import us.codecraft.webmagic.Site;
+import us.codecraft.webmagic.Spider;
+import us.codecraft.webmagic.processor.PageProcessor;
+
+import javax.management.JMException;
+
+/**
+ * @author jerry_shenchao@163.com
+ */
+public class SeedUrlWithPortTest {
+
+    @Test
+    public void testSeedUrlWithPort() throws JMException {
+        Spider spider = Spider.create(new TempProcessor()).addUrl("http://www.hndpf.org:8889/");
+        SpiderMonitor.instance().register(spider);
+        spider.run();
+    }
+}
+
+class TempProcessor implements PageProcessor {
+
+    @Override
+    public void process(Page page) {
+
+    }
+
+    @Override
+    public Site getSite() {
+        return Site.me();
+    }
+}


### PR DESCRIPTION
发现一个bug，当种子url带有端口时，如果对爬虫进行监控，会报如下错误javax.management.MalformedObjectNameException: Invalid character ':' in value part of property
建议在getDomain中进行进一步验证性检测
