### PR TITLE
fix a bug of RegexSelector when regex has zero-width assertions.

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/RegexSelector.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/RegexSelector.java
@@ -28,8 +28,7 @@ public class RegexSelector implements Selector {
         }
         // Check bracket for regex group. Add default group 1 if there is no group.
         // Only check if there exists the valid left parenthesis, leave regexp validation for Pattern.
-        if (StringUtils.countMatches(regexStr, "(") - StringUtils.countMatches(regexStr, "\\(") ==
-                StringUtils.countMatches(regexStr, "(?:") - StringUtils.countMatches(regexStr, "\\(?:")) {
+        if ( ! hasGroup(regexStr) ){
             regexStr = "(" + regexStr + ")";
         }
         this.regexStr = regexStr;
@@ -43,6 +42,30 @@ public class RegexSelector implements Selector {
 
     public RegexSelector(String regexStr) {
         this(regexStr, 1);
+    }
+
+    private boolean hasGroup(String regexStr) {
+        if (StringUtils.countMatches(regexStr, "(") - StringUtils.countMatches(regexStr, "\\(") ==
+                StringUtils.countMatches(regexStr, "(?:") - StringUtils.countMatches(regexStr, "\\(?:")){
+            return false;
+        }
+        if (StringUtils.countMatches(regexStr, "(") - StringUtils.countMatches(regexStr, "\\(") ==
+                StringUtils.countMatches(regexStr, "(?=") - StringUtils.countMatches(regexStr, "\\(?=") ) {
+            return false;
+        }
+        if (StringUtils.countMatches(regexStr, "(") - StringUtils.countMatches(regexStr, "\\(") ==
+                StringUtils.countMatches(regexStr, "(?<") - StringUtils.countMatches(regexStr, "\\(?<") ) {
+            return false;
+        }
+        if (StringUtils.countMatches(regexStr, "(") - StringUtils.countMatches(regexStr, "\\(") ==
+                StringUtils.countMatches(regexStr, "(?!") - StringUtils.countMatches(regexStr, "\\(?!") ) {
+            return false;
+        }
+        if (StringUtils.countMatches(regexStr, "(") - StringUtils.countMatches(regexStr, "\\(") ==
+                StringUtils.countMatches(regexStr, "(?#") - StringUtils.countMatches(regexStr, "\\(?#") ) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/webmagic-core/src/test/java/us/codecraft/webmagic/selector/RegexSelectorTest.java
+++ b/webmagic-core/src/test/java/us/codecraft/webmagic/selector/RegexSelectorTest.java
@@ -22,4 +22,20 @@ public class RegexSelectorTest {
         String select = regexSelector.select(source);
         Assertions.assertThat(select).isEqualTo(source);
     }
+
+    @Test
+    public void testRegexWithZeroWidthAssertions() {
+        String regex = "^.*(?=\\?)";
+        String source = "hello world?xxxx";
+        RegexSelector regexSelector = new RegexSelector(regex);
+        String select = regexSelector.select(source);
+        Assertions.assertThat(select).isEqualTo("hello world");
+
+
+        regex = "\\d{3}(?!\\d)";
+        source = "123456asdf";
+        regexSelector = new RegexSelector(regex);
+        select = regexSelector.select(source);
+        Assertions.assertThat(select).isEqualTo("456");
+    }
 }


### PR DESCRIPTION
解决在正则表达式包含零宽断言情况下RegexSelector的报错。

#491 