### PR TITLE
修复formatter初始化未传参bug

### DIFF
--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/model/PageModelExtractor.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/model/PageModelExtractor.java
@@ -115,7 +115,11 @@ class PageModelExtractor {
     }
 
     private ObjectFormatter getObjectFormatter(Field field, Class<?> fieldClazz, Formatter formatter) {
-        return initFormatter(ObjectFormatters.get(fieldClazz));
+        ObjectFormatter objectFormatter = initFormatter(ObjectFormatters.get(fieldClazz));
+        if(formatter != null && formatter.value() != null){
+          objectFormatter.initParam(formatter.value());
+        }
+        return objectFormatter;
     }
 
     private ObjectFormatter initFormatter(Class<? extends ObjectFormatter> formatterClazz) {


### PR DESCRIPTION
注解方式抽取Field的时候，Formatter传递的参数并为传递给生成的ObjectFormatter对象。
下图是出现bug的注解。
![image](https://cloud.githubusercontent.com/assets/3490283/26435844/b64420b2-4144-11e7-81ef-8ca8df3f0b5b.png)

修复的代码在getObjectFormatter 时，调用了initParam方法。