### PR TITLE
删除构造函数防止误用

### DIFF
--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/model/OOSpider.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/model/OOSpider.java
@@ -53,10 +53,6 @@ public class OOSpider<T> extends Spider {
         this.modelPageProcessor = modelPageProcessor;
     }
 
-    public OOSpider(PageProcessor pageProcessor) {
-        super(pageProcessor);
-    }
-
     /**
      * create a spider
      *


### PR DESCRIPTION
现在的接口可能存在误用：

```
class GithubPageProcessor implements PageProcessor;
class SomePageModelPipeline implements PageModelPipeline;
new OOSpider(new GithubPageProcessor())
    .addPageModel(new SomePageModelPipeline(), Page.class)    // NullPointerException
    .run();
```

尽管不会有人这么写，我觉得仍然有必要删除掉这个构造函数。