### PR TITLE
#fixbug shutdown executorService incorrect

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/Spider.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/Spider.java
@@ -373,7 +373,9 @@ public class Spider implements Runnable, Task {
         for (Pipeline pipeline : pipelines) {
             destroyEach(pipeline);
         }
-        threadPool.shutdown();
+        if (executorService == null) {
+            threadPool.shutdown();
+        }
     }
 
     private void destroyEach(Object object) {


### PR DESCRIPTION
通过setExecutorService()方法设置的线程池不应被spider shutdown ，如
```
Spider.create(...).setExecutorService(exec).run();
Spider.create(...).setExecutorService(exec).run();
```
第二个spider无法使用exec，因为前一个close时把线程池关闭了