### PR TITLE
extend the four-component to every request

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/Request.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/Request.java
@@ -1,6 +1,12 @@
 package us.codecraft.webmagic;
 
+import java.util.ArrayList;
+import java.util.List;
+import us.codecraft.webmagic.downloader.Downloader;
 import us.codecraft.webmagic.model.HttpRequestBody;
+import us.codecraft.webmagic.pipeline.Pipeline;
+import us.codecraft.webmagic.processor.PageProcessor;
+import us.codecraft.webmagic.scheduler.Scheduler;
 import us.codecraft.webmagic.utils.Experimental;
 
 import java.io.Serializable;
@@ -52,6 +58,14 @@ public class Request implements Serializable {
     private boolean binaryContent = false;
 
     private String charset;
+
+    private Downloader downloader;
+
+    private PageProcessor pageProcessor;
+
+    private Scheduler scheduler;
+
+    private List<Pipeline> pipelines = new ArrayList<Pipeline>();
 
     public Request() {
     }
@@ -186,6 +200,38 @@ public class Request implements Serializable {
     public Request setCharset(String charset) {
         this.charset = charset;
         return this;
+    }
+
+    public Downloader getDownloader() {
+        return downloader;
+    }
+
+    public void setDownloader(Downloader downloader) {
+        this.downloader = downloader;
+    }
+
+    public PageProcessor getPageProcessor() {
+        return pageProcessor;
+    }
+
+    public void setPageProcessor(PageProcessor pageProcessor) {
+        this.pageProcessor = pageProcessor;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public List<Pipeline> getPipelines() {
+        return pipelines;
+    }
+
+    public void addPipelines(Pipeline pipeline) {
+        this.pipelines.add(pipeline);
     }
 
     @Override


### PR DESCRIPTION
>对每一个请求，进行可定制化配置，即每个请求包含自己的downloader,processor,scheduler和pipeline,
如果没有设置则走默认的
举个例子，当你在爬虫的时候，有的请求只需要httpclient进行简单的页面请求，但同时有的请求却要进行phantomjs的本地js操作，这种情形下为了拥有js操作的功能，我们只能选后者的downloader，即使逻辑复杂化又降低了性能（仿浏览器操作比简单的网络请求消耗更多资源），代码耦合性也很高