### PR TITLE
支持直接用编译后的RegexSelector进行选择

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/AbstractSelectable.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/AbstractSelectable.java
@@ -83,6 +83,11 @@ public abstract class AbstractSelectable implements Selectable {
         RegexSelector regexSelector = Selectors.regex(regex, group);
         return selectList(regexSelector, getSourceTexts());
     }
+    
+    @Override
+    public Selectable regex(RegexSelector selector) {
+        return selectList(selector, getSourceTexts());
+    }
 
     @Override
     public Selectable replace(String regex, String replacement) {

--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/Selectable.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/Selectable.java
@@ -82,6 +82,13 @@ public interface Selectable {
      * @return new Selectable after extract
      */
     public Selectable regex(String regex, int group);
+    
+    /**
+     * select list with RegexSelector
+     * @param selector selector
+     * @return Selectable after extract
+     */
+    public Selectable regex(RegexSelector selector);
 
     /**
      * replace with regex


### PR DESCRIPTION
不需要每次都重复编译同一条正则表达式