### PR TITLE
Fix Spider main thread any problem with redis connection (when working with redis-based schedulers) leads to unhandled exception and release the main (control) thread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,13 @@
         <version>7</version>
     </parent>
     <groupId>us.codecraft</groupId>
-    <version>0.7.3</version>
+    <version>0.7.5</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring-version>4.0.0.RELEASE</spring-version>
-
     </properties>
     <artifactId>webmagic-parent</artifactId>
     <name>webmagic-parent</name>
@@ -62,12 +61,6 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.11</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.10.19</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/webmagic-core/pom.xml
+++ b/webmagic-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>us.codecraft</groupId>
         <artifactId>webmagic-parent</artifactId>
-        <version>0.7.3</version>
+        <version>0.7.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webmagic-core/src/main/java/us/codecraft/webmagic/Spider.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/Spider.java
@@ -305,7 +305,13 @@ public class Spider implements Runnable, Task {
         initComponent();
         logger.info("Spider {} started!",getUUID());
         while (!Thread.currentThread().isInterrupted() && stat.get() == STAT_RUNNING) {
-            final Request request = scheduler.poll(this);
+            final Request request;
+            try {
+                request = scheduler.poll(this);
+            } catch (Exception e) {
+                logger.warn(e.getMessage());
+                continue;
+            }
             if (request == null) {
                 if (threadPool.getThreadAlive() == 0 && exitWhenComplete) {
                     break;

--- a/webmagic-extension/pom.xml
+++ b/webmagic-extension/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>us.codecraft</groupId>
         <artifactId>webmagic-parent</artifactId>
-        <version>0.7.3</version>
+        <version>0.7.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webmagic-samples/pom.xml
+++ b/webmagic-samples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>webmagic-parent</artifactId>
         <groupId>us.codecraft</groupId>
-        <version>0.7.3</version>
+        <version>0.7.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webmagic-saxon/pom.xml
+++ b/webmagic-saxon/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>webmagic-parent</artifactId>
         <groupId>us.codecraft</groupId>
-        <version>0.7.3</version>
+        <version>0.7.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/webmagic-scripts/pom.xml
+++ b/webmagic-scripts/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>webmagic-parent</artifactId>
         <groupId>us.codecraft</groupId>
-        <version>0.7.3</version>
+        <version>0.7.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>us.codecraft</groupId>
     <artifactId>webmagic-scripts</artifactId>
+    
     <properties>
         <kotlin.version>1.1.2-2</kotlin.version>
     </properties>

--- a/webmagic-selenium/pom.xml
+++ b/webmagic-selenium/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>webmagic-parent</artifactId>
 		<groupId>us.codecraft</groupId>
-		<version>0.7.3</version>
+		<version>0.7.5</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
```
Exception in thread "Thread-5" redis.clients.jedis.exceptions.JedisConnectionException: Unexpected end of stream.
    at redis.clients.util.RedisInputStream.ensureFill(RedisInputStream.java:199)
    at redis.clients.util.RedisInputStream.readByte(RedisInputStream.java:40)
    at redis.clients.jedis.Protocol.process(Protocol.java:151)
    at redis.clients.jedis.Protocol.read(Protocol.java:215)
    at redis.clients.jedis.Connection.readProtocolWithCheckingBroken(Connection.java:340)
    at redis.clients.jedis.Connection.getStatusCodeReply(Connection.java:239)
    at redis.clients.jedis.BinaryJedis.select(BinaryJedis.java:523)
    at us.codecraft.webmagic.scheduler.RedisPriorityScheduler.poll(RedisPriorityScheduler.java:63)
    at us.codecraft.webmagic.Spider.run(Spider.java:309)
    at java.lang.Thread.run(Thread.java:748)
```