### PR TITLE
分布式redis爬虫缓存清理支持

### DIFF
--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/RedisScheduler.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/RedisScheduler.java
@@ -126,4 +126,19 @@ public class RedisScheduler extends DuplicateRemovedScheduler implements Monitor
             pool.returnResource(jedis);
         }
     }
+
+    /**
+     * clean all current task redis queue
+     * @param task current task
+     */
+    public void flush(Task task) {
+        Jedis jedis = pool.getResource();
+        try {
+            jedis.del(getSetKey(task));
+            jedis.del(getQueueKey(task));
+            jedis.del(getItemKey(task));
+        } finally {
+            pool.returnResource(jedis);
+        }
+    }
 }

--- a/webmagic-extension/src/test/java/us/codecraft/webmagic/scheduler/RedisSchedulerTest.java
+++ b/webmagic-extension/src/test/java/us/codecraft/webmagic/scheduler/RedisSchedulerTest.java
@@ -15,16 +15,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RedisSchedulerTest {
 
     private RedisScheduler redisScheduler;
+    private Task task;
 
     @Before
     public void setUp() {
         redisScheduler = new RedisScheduler("localhost");
-    }
 
-    @Ignore("environment depended")
-    @Test
-    public void test() {
-        Task task = new Task() {
+        task = new Task() {
             @Override
             public String getUUID() {
                 return "1";
@@ -35,11 +32,32 @@ public class RedisSchedulerTest {
                 return null;
             }
         };
+    }
+
+    @Ignore("environment depended")
+    @Test
+    public void test() {
         Request request = new Request("http://www.ibm.com/developerworks/cn/java/j-javadev2-22/");
         request.putExtra("1","2");
         redisScheduler.push(request, task);
         Request poll = redisScheduler.poll(task);
         assertThat(poll).isEqualTo(request);
+
+    }
+
+    @Ignore("environment depended")
+    @Test
+    public void testFlush() {
+        Request request = new Request("http://www.baidu.com");
+        request.putExtra("1","2");
+        redisScheduler.push(request, task);
+        int totalRequestsCount = redisScheduler.getTotalRequestsCount(task);
+        assertThat(totalRequestsCount).isGreaterThan(0);
+        redisScheduler.flush(task);
+        totalRequestsCount = redisScheduler.getTotalRequestsCount(task);
+        assertThat(totalRequestsCount).isEqualTo(0);
+        int leftRequestsCount = redisScheduler.getLeftRequestsCount(task);
+        assertThat(leftRequestsCount).isEqualTo(0);
 
     }
 }


### PR DESCRIPTION
鉴于目前webmagic主要参考与scrapy，我找到了scrapy的redis分布式方案scrapy-redis.
通过对比当前webmagic源码与scrapy-redis源码发现，RedisScheduler中缺少对于queue的清理。
以scrapy-redis中的源码为例
scrapy-redis/src/scrapy-redis/scheduler.py

...
class Scheduler(object):
...
def open(self, spider):
...
if self.flush_on_start:
self.flush()
# notice if there are requests already in the queue to resume the crawl
if len(self.queue):
spider.log("Resuming crawl (%d requests scheduled)" % len(self.queue))

def close(self, reason):
if not self.persist:
self.flush()

def flush(self):
self.df.clear()
self.queue.clear()
scrapy-redis/src/scrapy_redis/queue.py

class Base(object):
...
def clear(self):
"""Clear queue/stack"""
self.server.delete(self.key)
...
scrapy-redis/src/scrapy_redis/dupefilter.py

class RFPDupeFilter(BaseDupeFilter):
...
def close(self, reason=''):
"""Delete data on close. Called by Scrapy's scheduler.
Parameters
----------
reason : str, optional
"""
self.clear()

def clear(self):
    """Clears fingerprints data."""
    self.server.delete(self.key)
...
个人对python不熟悉，简单理解了一下，flush_on_start可以设置为启动的时候对当前实例执行flush清理。或者使用者可以主动调用flush()根据自己的情况进行清理
这里的清理是对key的完整清理。

反观Webmagic这边
webmagic/webmagic-extension/src/main/java/us/codecraft/webmagic/scheduler/RedisScheduler.java

public class RedisScheduler extends DuplicateRemovedScheduler implements MonitorableScheduler, DuplicateRemover {

private static final String QUEUE_PREFIX = "queue_";

private static final String SET_PREFIX = "set_";

private static final String ITEM_PREFIX = "item_";

...
@Override
public void resetDuplicateCheck(Task task) {
    Jedis jedis = pool.getResource();
    try {
        jedis.del(getSetKey(task));
    } finally {
        pool.returnResource(jedis);
    }
}
...
protected String getSetKey(Task task) {
    return SET_PREFIX + task.getUUID();
}

protected String getQueueKey(Task task) {
    return QUEUE_PREFIX + task.getUUID();
}

protected String getItemKey(Task task)
{
    return ITEM_PREFIX + task.getUUID();
}
...
这里只有DuplicateRemover接口中定义了一个resetDuplicateCheck方法对set_这个key进行了清理动作。
场景举例:目前有多台爬虫机器，一个redis服务。如果这个爬虫集群处理完第一批数据后，理论上来说第
二批数据属于主观需要抓取的，无论是与第一批数据是否重复。那么这里就需要清理之前的queue。
但是实际上的效果是，目前只能调用resetDuplicateCheck进行排除重复。但是随着数据量的持续上升
item_TASKID的队列一直没有得到清理。如下图所示：
redis内存使用（图太久了已裂）
实际情况（图太久了已裂）
其中set_可以得到清理。