### PR TITLE
SpiderStatus中getPagePerSecond()方法，增加验证逻辑，避免空指针，避免除数为零。

### DIFF
--- a/webmagic-extension/src/main/java/us/codecraft/webmagic/monitor/SpiderStatus.java
+++ b/webmagic-extension/src/main/java/us/codecraft/webmagic/monitor/SpiderStatus.java
@@ -84,8 +84,13 @@ public class SpiderStatus implements SpiderStatusMXBean {
 
     @Override
     public int getPagePerSecond() {
-        int runSeconds = (int) (System.currentTimeMillis() - getStartTime().getTime()) / 1000;
-        return getSuccessPageCount() / runSeconds;
+        if (getStartTime() != null) {
+            int runSeconds = (int) (System.currentTimeMillis() - getStartTime().getTime()) / 1000;
+            if (runSeconds != 0) {
+                return getSuccessPageCount() / runSeconds;
+            }
+        }
+        return -1;
     }
 
 }


### PR DESCRIPTION


```java
    @Override
    public int getPagePerSecond() {
        if (getStartTime() != null) {
            int runSeconds = (int) (System.currentTimeMillis() - getStartTime().getTime()) / 1000;
            if (runSeconds != 0) {
                return getSuccessPageCount() / runSeconds;
            }
        }
        return -1;
    }
```

增加判断逻辑，避免常见异常类型。