### PR TITLE
修复 HtmlCleaner 无法正常解析 tr 和 td 标签的问题

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/BaseElementSelector.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/BaseElementSelector.java
@@ -3,6 +3,7 @@ package us.codecraft.webmagic.selector;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import us.codecraft.webmagic.utils.BaseSelectorUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,16 +14,9 @@ import java.util.List;
  */
 public abstract class BaseElementSelector implements Selector, ElementSelector {
     private Document parse(String text) {
-        if (text == null) {
-            return null;
-        }
-
         // Jsoup could not parse <tr></tr> or <td></td> tag directly
         // https://stackoverflow.com/questions/63607740/jsoup-couldnt-parse-tr-tag
-        if ((text.startsWith("<tr>") && text.endsWith("</tr>"))
-                || (text.startsWith("<td>") && text.endsWith("</td>"))) {
-            text = "<table>" + text + "</table>";
-        }
+        text = BaseSelectorUtils.preParse(text);
         return Jsoup.parse(text);
     }
 

--- a/webmagic-core/src/main/java/us/codecraft/webmagic/utils/BaseSelectorUtils.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/utils/BaseSelectorUtils.java
@@ -1,0 +1,23 @@
+package us.codecraft.webmagic.utils;
+
+/**
+ * @author hooy
+ */
+public class BaseSelectorUtils {
+
+    /**
+     * Jsoup/HtmlCleaner could not parse "tr" or "td" tag directly
+     * https://stackoverflow.com/questions/63607740/jsoup-couldnt-parse-tr-tag
+     *
+     * @param text - the html string
+     * @return text
+     */
+    public static String preParse(String text) {
+        if (((text.startsWith("<tr>") || text.startsWith("<tr ")) && text.endsWith("</tr>"))
+                || ((text.startsWith("<td>") || text.startsWith("<td ")) && text.endsWith("</td>"))) {
+            text = "<table>" + text + "</table>";
+        }
+        return text;
+    }
+
+}

--- a/webmagic-saxon/src/test/java/us/codecraft/webmagic/selector/XpathSelectorTest.java
+++ b/webmagic-saxon/src/test/java/us/codecraft/webmagic/selector/XpathSelectorTest.java
@@ -1393,12 +1393,13 @@ public class XpathSelectorTest {
     public void htmlCleanerParseTest() {
         Spider.create(new RuoxiaPageProcessor()).addUrl("http://www.ruoxia.com/top/dianji/month").thread(1).run();
     }
+
     class RuoxiaPageProcessor implements PageProcessor {
         @Override
         public void process(Page page) {
-            List<Selectable> nodes = page.getHtml().xpath("//div[@class=\"bd\"]//tbody/tr").nodes();
-            for (Selectable node:nodes) {
-                String name = node.xpath("//td[3]/div/a[1]/text()").get();
+            List<String> items = new Xpath2Selector("//div[@class=\"bd\"]//tbody/tr").selectList(page.getRawText());
+            for (String item : items) {
+                String name = new Xpath2Selector("//td[3]/div/a[1]/text()").select(item);
                 System.out.println(name);
             }
         }
@@ -1408,31 +1409,31 @@ public class XpathSelectorTest {
     @Test
     public void performanceTest() {
         Xpath2Selector xpath2Selector = new Xpath2Selector("//a");
-        long time =System.currentTimeMillis();
+        long time = System.currentTimeMillis();
         for (int i = 0; i < 1000; i++) {
             xpath2Selector.selectList(html);
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
         XpathSelector xpathSelector = new XpathSelector("//a");
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 1000; i++) {
             xpathSelector.selectList(html);
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 1000; i++) {
             xpath2Selector.selectList(html);
         }
         System.out.println(System.currentTimeMillis() - time);
 
         CssSelector cssSelector = new CssSelector("a");
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 1000; i++) {
             cssSelector.selectList(html);
         }
-        System.out.println("css "+(System.currentTimeMillis()-time));
+        System.out.println("css " + (System.currentTimeMillis() - time));
     }
 
     @Ignore("take long time")
@@ -1444,54 +1445,54 @@ public class XpathSelectorTest {
         TagNode tagNode = htmlCleaner.clean(html);
         Document document = Jsoup.parse(html);
 
-        long time =System.currentTimeMillis();
+        long time = System.currentTimeMillis();
         for (int i = 0; i < 2000; i++) {
             htmlCleaner.clean(html);
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 2000; i++) {
             tagNode.evaluateXPath("//a");
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
         System.out.println("=============");
 
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 2000; i++) {
             Jsoup.parse(html);
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 2000; i++) {
             document.select("a");
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
         System.out.println("=============");
 
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 2000; i++) {
             htmlCleaner.clean(html);
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 2000; i++) {
             tagNode.evaluateXPath("//a");
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
         System.out.println("=============");
 
         XPathEvaluator compile = Xsoup.compile("//a");
-        time =System.currentTimeMillis();
+        time = System.currentTimeMillis();
         for (int i = 0; i < 2000; i++) {
             compile.evaluate(document);
         }
-        System.out.println(System.currentTimeMillis()-time);
+        System.out.println(System.currentTimeMillis() - time);
 
     }
 

--- a/webmagic-saxon/src/test/java/us/codecraft/webmagic/selector/XpathSelectorTest.java
+++ b/webmagic-saxon/src/test/java/us/codecraft/webmagic/selector/XpathSelectorTest.java
@@ -11,6 +11,9 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import us.codecraft.webmagic.Page;
+import us.codecraft.webmagic.Spider;
+import us.codecraft.webmagic.processor.PageProcessor;
 import us.codecraft.xsoup.XPathEvaluator;
 import us.codecraft.xsoup.Xsoup;
 
@@ -1383,6 +1386,22 @@ public class XpathSelectorTest {
         List<String> selectList = xpath2Selector.selectList(html);
         Assert.assertEquals(113, selectList.size());
         Assert.assertEquals("http://www.oschina.net/", selectList.get(0));
+    }
+
+    @Ignore("test parse <table> <tr> <td> tag")
+    @Test
+    public void htmlCleanerParseTest() {
+        Spider.create(new RuoxiaPageProcessor()).addUrl("http://www.ruoxia.com/top/dianji/month").thread(1).run();
+    }
+    class RuoxiaPageProcessor implements PageProcessor {
+        @Override
+        public void process(Page page) {
+            List<Selectable> nodes = page.getHtml().xpath("//div[@class=\"bd\"]//tbody/tr").nodes();
+            for (Selectable node:nodes) {
+                String name = node.xpath("//td[3]/div/a[1]/text()").get();
+                System.out.println(name);
+            }
+        }
     }
 
     @Ignore("take long time")


### PR DESCRIPTION
Jsoup 和 HtmlCleaner 构建 Dom 时，若缺失 table 标签，则无法正常解析 tr 和 td 标签。