### PR TITLE
Refactored to remove multiple calls of getSourceTexts() api

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/AbstractSelectable.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/AbstractSelectable.java
@@ -3,6 +3,7 @@ package us.codecraft.webmagic.selector;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.commons.collections4.CollectionUtils;
 
 /**
@@ -55,11 +56,12 @@ public abstract class AbstractSelectable implements Selectable {
 
     @Override
     public String get() {
-        if (CollectionUtils.isNotEmpty(all())) {
-            return all().get(0);
-        } else {
-            return null;
-        }
+    	List<String> sourceTexts = all();
+        if (CollectionUtils.isNotEmpty(sourceTexts)) {
+            return sourceTexts.get(0);
+        } 
+        return null;
+        
     }
 
     @Override
@@ -91,8 +93,9 @@ public abstract class AbstractSelectable implements Selectable {
     }
 
     public String getFirstSourceText() {
-        if (getSourceTexts() != null && getSourceTexts().size() > 0) {
-            return getSourceTexts().get(0);
+    	List<String> sourceTexts = getSourceTexts();
+        if (CollectionUtils.isNotEmpty(sourceTexts)) {
+            return sourceTexts.get(0);
         }
         return null;
     }
@@ -104,6 +107,6 @@ public abstract class AbstractSelectable implements Selectable {
 
     @Override
     public boolean match() {
-        return getSourceTexts() != null && getSourceTexts().size() > 0;
+        return CollectionUtils.isNotEmpty(getSourceTexts());
     }
 }


### PR DESCRIPTION
a. AbstractSelectable#getFirstSourceText() method is calling getSourceTexts() multiple times, not required to address this usecase
b. Remove unnecessary else block in AbstractSelectable#get() method.
c. AbstractSelectable#match method is calling getSourceTexts() multiple times, not required to address this usecase.