### PR TITLE
FileCacheQueueScheduler使用BloomFilter进行去重

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/Spider.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/Spider.java
@@ -187,7 +187,7 @@ public class Spider implements Runnable, Task {
      */
     public Spider setScheduler(Scheduler updateScheduler) {
         checkIfRunning();
-        SpiderScheduler oldScheduler = this.scheduler;
+        Scheduler oldScheduler = scheduler.getScheduler();
         scheduler.setScheduler(updateScheduler);
         if (oldScheduler != null) {
             Request request;
@@ -458,7 +458,6 @@ public class Spider implements Runnable, Task {
             logger.info("page status code error, page {} , code: {}", request.getUrl(), page.getStatusCode());
         }
         sleep(site.getSleepTime());
-        return;
     }
 
     private void onDownloaderFail(Request request) {


### PR DESCRIPTION
修改的内容如下：
1.  去重器换成了BloomFilter , 去掉了其中urls属性，防止抓起的网页过多导致内存爆炸
2.  优化了格式和import行
3.  避免readCursorFile中重复创建AtomicInteger对象
