### PR TITLE
修改SmartContentSelector threshold可定制化

### DIFF
--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/HtmlNode.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/HtmlNode.java
@@ -31,6 +31,11 @@ public class HtmlNode extends AbstractSelectable {
         return select(smartContentSelector, getSourceTexts());
     }
 
+    public Selectable smartContent(int threshold) {
+        SmartContentSelector smartContentSelector = Selectors.smartContent(threshold);
+        return select(smartContentSelector, getSourceTexts());
+    }
+
     @Override
     public Selectable links() {
         return selectElements(new LinksSelector());

--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/Selectors.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/Selectors.java
@@ -20,6 +20,10 @@ public abstract class Selectors {
         return new SmartContentSelector();
     }
 
+    public static SmartContentSelector smartContent(int threshold) {
+        return new SmartContentSelector(threshold);
+    }
+
     public static CssSelector $(String expr) {
         return new CssSelector(expr);
     }

--- a/webmagic-core/src/main/java/us/codecraft/webmagic/selector/SmartContentSelector.java
+++ b/webmagic-core/src/main/java/us/codecraft/webmagic/selector/SmartContentSelector.java
@@ -16,7 +16,13 @@ import java.util.List;
 @Experimental
 public class SmartContentSelector implements Selector {
 
+    private int threshold = 86;
+
     public SmartContentSelector() {
+    }
+
+    public SmartContentSelector(int threshold) {
+        this.threshold = threshold;
     }
 
     @Override
@@ -29,7 +35,6 @@ public class SmartContentSelector implements Selector {
         html = html.replaceAll("(?is)<.*?>", "");
         List<String> lines;
         int blocksWidth =3;
-        int threshold =86;
         int start;
         int end;
         StringBuilder text = new StringBuilder();


### PR DESCRIPTION
这个threshold是写死的86 导致爬某些网站的时候 由于文本内容比较短，爬取不到，我把他改成了可传入参数的形式。默认值还是86。